### PR TITLE
Guard image randomization, throttle mouse moves, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - **CSS**
 - **Redux Toolkit**
 - **RTK Query**
-- **Firebase**
+- **Redux Persist**
 
 **Please note that the app's layout is optimized only for tablets, laptops and desktops.**
 
@@ -43,4 +43,4 @@ npm install
 npm run dev
 ```
 
-This will start the development server. Open http://localhost:5173 to view it in the browser.
+This will start the development server. Open http://localhost:3000 to view it in the browser.

--- a/src/app/drawing/page.tsx
+++ b/src/app/drawing/page.tsx
@@ -15,6 +15,7 @@ import styles from './styles.module.scss'
 const Drawing = () => {
    const dispatch = useAppDispatch()
    const timeoutId = useRef<ReturnType<typeof setTimeout> | null>(null)
+   const lastMouseMoveAt = useRef(0)
    const [randomPageNumber, setRandomPageNumber] = useState(0)
 
    const { object, gender, clothing, count } =
@@ -34,6 +35,12 @@ const Drawing = () => {
    })
 
    const handleMouseMove = () => {
+      const now = Date.now()
+      if (now - lastMouseMoveAt.current < 100) {
+         return
+      }
+      lastMouseMoveAt.current = now
+
       dispatch(mouseIsMoving(true))
       if (timeoutId.current) clearTimeout(timeoutId.current)
 

--- a/src/utils/randomizeImages.ts
+++ b/src/utils/randomizeImages.ts
@@ -2,8 +2,13 @@ import { IImage } from '../api/types'
 
 export const randomizeImages = (imgCount: number, imgData?: IImage[]) => {
    imgData = imgData || []
+   const safeCount = Math.min(imgCount, imgData.length)
+   if (safeCount === 0) {
+      return []
+   }
+
    let randomIndexes = new Set<number>()
-   while (randomIndexes.size < imgCount) {
+   while (randomIndexes.size < safeCount) {
       randomIndexes.add(Math.floor(Math.random() * imgData.length))
    }
 


### PR DESCRIPTION
### Motivation
- Prevent runtime issues when `randomizeImages` is called with empty or smaller-than-requested image data.  
- Reduce dispatch frequency from high-rate `mousemove` events in the drawing session to improve responsiveness and CPU usage.  

### Description
- In `src/utils/randomizeImages.ts` compute `safeCount = Math.min(imgCount, imgData.length)` and return an empty array immediately when `safeCount === 0`, iterating only up to `safeCount`.  
- In `src/app/drawing/page.tsx` add a `lastMouseMoveAt` ref and a 100ms throttle check inside `handleMouseMove` to avoid excessive `dispatch(mouseIsMoving(true))` calls.  
- Update `README.md` to list `Redux Persist` in the technical stack and correct the development server URL to `http://localhost:3000`.  

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d6071d0c832da152086c21fa16bb)