### PR TITLE
Show Pinterest boards on /user and enforce single-board selection

### DIFF
--- a/backend/src/pinterest/pinterest.service.ts
+++ b/backend/src/pinterest/pinterest.service.ts
@@ -14,6 +14,7 @@ type AppBoard = {
    description: string | null;
    privacy: string | null;
    createdAt: string | null;
+   imageUrl: string | null;
 };
 
 type AppPin = {
@@ -85,6 +86,7 @@ export class PinterestService {
          description: board.description ?? null,
          privacy: board.privacy ?? null,
          createdAt: board.created_at ?? null,
+         imageUrl: this.pickBoardImageUrl(board),
       };
    }
 
@@ -108,5 +110,20 @@ export class PinterestService {
          .sort((a, b) => (b.width ?? 0) * (b.height ?? 0) - (a.width ?? 0) * (a.height ?? 0));
 
       return variantsWithSize[0]?.url ?? null;
+   }
+
+   private pickBoardImageUrl(board: PinterestBoardResponse) {
+      const rawMedia = board.media;
+      if (!rawMedia || typeof rawMedia !== 'object') {
+         return null;
+      }
+
+      const media = rawMedia as {
+         image_cover_url?: string;
+         cover_image_url?: string;
+         image_cover?: string;
+      };
+
+      return media.image_cover_url ?? media.cover_image_url ?? media.image_cover ?? null;
    }
 }

--- a/frontend/src/app/[user]/components/control-bar/data.ts
+++ b/frontend/src/app/[user]/components/control-bar/data.ts
@@ -8,7 +8,7 @@ export const data = {
    secondaryButton: {
       title: 'Reset all',
    },
-   emptyText: 'Select images to start drawing',
+   emptyText: 'Select one board to start drawing',
    selectOption: [
       {
          name: 'duration',

--- a/frontend/src/app/[user]/components/pins-list/index.tsx
+++ b/frontend/src/app/[user]/components/pins-list/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { AccountPin } from '@/services/pinterest-pins'
+import type { AccountBoard } from '@/services/pinterest-boards'
 import cn from 'classnames'
 import Image from 'next/image'
 import { useEffect } from 'react'
@@ -10,31 +10,53 @@ import { setPins, togglePinSelection } from '@/store/slices/pins-slice'
 import styles from './styles.module.scss'
 
 type PinsListProps = {
-   pins: AccountPin[]
+   boards: AccountBoard[]
 }
 
-const PinsList = ({ pins }: PinsListProps) => {
+const PinsList = ({ boards }: PinsListProps) => {
    const dispatch = useAppDispatch()
    const selectedPins = useAppSelector((state) => state.pins.selectedPins)
 
    useEffect(() => {
-      dispatch(setPins(pins))
-   }, [dispatch, pins])
+      dispatch(
+         setPins(
+            boards.map((board) => ({
+               id: board.id,
+               title: board.name,
+               description: board.description,
+               link: null,
+               createdAt: board.createdAt,
+               imageUrl: board.imageUrl,
+            })),
+         ),
+      )
+   }, [boards, dispatch])
 
-   if (pins.length === 0) {
-      return <p className={styles.pins__empty}>No Pinterest pins yet.</p>
+   if (boards.length === 0) {
+      return <p className={styles.pins__empty}>No Pinterest boards yet.</p>
    }
 
    return (
       <section className={styles.pins}>
-         {pins.map((pin) => {
-            const isSelected = selectedPins.some((selectedPin) => selectedPin.id === pin.id)
+         {boards.map((board) => {
+            const isSelected = selectedPins.some((selectedPin) => selectedPin.id === board.id)
 
             return (
                <button
-                  key={pin.id}
+                  key={board.id}
                   type="button"
-                  onClick={() => dispatch(togglePinSelection(pin))}
+                  onClick={() =>
+                     dispatch(
+                        togglePinSelection({
+                           id: board.id,
+                           title: board.name,
+                           description: board.description,
+                           link: null,
+                           createdAt: board.createdAt,
+                           imageUrl: board.imageUrl,
+                        }),
+                     )
+                  }
                   className={cn(styles.pin, {
                      [styles['pin--selected']]: isSelected,
                   })}
@@ -44,17 +66,20 @@ const PinsList = ({ pins }: PinsListProps) => {
                      <FaCheck className={styles['pin__selected-icon-check']} />
                   </span>
                   <div className={styles['pin__image-wrap']}>
-                     {pin.imageUrl ? (
+                     {board.imageUrl ? (
                         <Image
                            fill={true}
-                           src={pin.imageUrl}
-                           alt={`Pinterest pin ${pin.id}`}
+                           src={board.imageUrl}
+                           alt={`Pinterest board ${board.name ?? board.id}`}
                            className={styles['pin__image']}
                            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                         />
                      ) : (
-                        <div className={styles['pin__placeholder']}>No image</div>
+                        <div className={styles['pin__placeholder']}>No preview</div>
                      )}
+                  </div>
+                  <div className={styles['pin__body']}>
+                     <h3 className={styles['pin__title']}>{board.name ?? 'Untitled board'}</h3>
                   </div>
                </button>
             )

--- a/frontend/src/app/[user]/page.tsx
+++ b/frontend/src/app/[user]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation'
 import { data as headerData } from '@/components/header/data'
 import IconButton from '@/components/ui/buttons/icon-button'
 import { getSessionUser } from '@/services/auth'
-import { getPinterestPins } from '@/services/pinterest-pins'
+import { getPinterestBoards } from '@/services/pinterest-boards'
 import ControlBar from './components/control-bar'
 import PinsList from './components/pins-list'
 import UserInfo from './components/user-info'
@@ -22,8 +22,8 @@ export default async function UserPage({ params }: PageProps) {
    }
 
    const username = decodeURIComponent(session.user)
-   const pinsResponse = await getPinterestPins()
-   const { items: pins = [] } = pinsResponse ?? {}
+   const boardsResponse = await getPinterestBoards()
+   const { items: boards = [] } = boardsResponse ?? {}
    const { logo } = headerData
 
    return (
@@ -37,7 +37,7 @@ export default async function UserPage({ params }: PageProps) {
             </div>
             <UserInfo username={username} profileImageUrl={session.profileImageUrl} />
          </div>
-         <PinsList pins={pins} />
+         <PinsList boards={boards} />
          <ControlBar />
       </main>
    )

--- a/frontend/src/services/pinterest-boards.ts
+++ b/frontend/src/services/pinterest-boards.ts
@@ -1,0 +1,36 @@
+import { cookies } from 'next/headers'
+
+export type AccountBoard = {
+   id: string
+   name: string | null
+   description: string | null
+   privacy: string | null
+   createdAt: string | null
+   imageUrl: string | null
+}
+
+type BoardsListResponse = {
+   items: AccountBoard[]
+   bookmark: string | null
+}
+
+export async function getPinterestBoards(pageSize = 24): Promise<BoardsListResponse | null> {
+   const backendUrl = process.env.BACKEND_API_URL
+   if (!backendUrl) {
+      throw new Error('BACKEND_API_URL is not set')
+   }
+
+   const sessionCookieName = process.env.SESSION_COOKIE_NAME ?? 'qd_session'
+   const cookieStore = await cookies()
+   const sessionToken = cookieStore.get(sessionCookieName)?.value
+   const response = await fetch(`${backendUrl}/pinterest/boards?page_size=${pageSize}`, {
+      headers: sessionToken ? { cookie: `${sessionCookieName}=${sessionToken}` } : undefined,
+      cache: 'no-store',
+   })
+
+   if (!response.ok) {
+      return null
+   }
+
+   return (await response.json()) as BoardsListResponse
+}

--- a/frontend/src/store/slices/pins-slice/index.ts
+++ b/frontend/src/store/slices/pins-slice/index.ts
@@ -27,13 +27,13 @@ const pinsSlice = createSlice({
             return
          }
 
-         const pinIndex = state.selectedPins.findIndex((selectedPin) => selectedPin.id === pin.id)
-         if (pinIndex >= 0) {
-            state.selectedPins.splice(pinIndex, 1)
+         const isSelected = state.selectedPins.some((selectedPin) => selectedPin.id === pin.id)
+         if (isSelected) {
+            state.selectedPins = []
             return
          }
 
-         state.selectedPins.push(pin)
+         state.selectedPins = [pin]
       },
       resetPinSelection: (state) => {
          state.selectedPins = []


### PR DESCRIPTION
### Motivation
- Replace the current pins view on the `/<user>` page with Pinterest boards so users see board previews and titles instead of individual pins.
- Restrict selection to a single board at a time so the drawing flow always receives exactly one selected board.

### Description
- Switched the data source on the user page from `getPinterestPins` to `getPinterestBoards` and pass `boards` to the list component (`frontend/src/app/[user]/page.tsx`).
- Added a new frontend service `getPinterestBoards` and `AccountBoard` type to fetch `/pinterest/boards` (`frontend/src/services/pinterest-boards.ts`).
- Reworked the list component to render boards with preview image and board name and to map boards into the existing pin shape for downstream components (`frontend/src/app/[user]/components/pins-list/index.tsx`).
- Changed selection behavior in the pins slice so the store keeps at most one selected item and clicking an already-selected board clears selection (`frontend/src/store/slices/pins-slice/index.ts`).
- Updated control bar empty-state copy to instruct selecting one board (`frontend/src/app/[user]/components/control-bar/data.ts`).
- Backend: extended board normalization with an `imageUrl` field and added `pickBoardImageUrl` to extract a preview from `board.media` so the frontend can show board previews (`backend/src/pinterest/pinterest.service.ts`).

### Testing
- Ran `yarn --cwd frontend build`: Next compiled but prerender failed because `BACKEND_API_URL` is not set in this environment, so build exited with an error (prerender error).
- Ran `yarn --cwd frontend run lint`: failed in this environment due to project layout resolving to an invalid `frontend/lint` path (tooling issue, not code logic).
- Ran `yarn --cwd backend build`: failed due to existing backend TypeScript/Prisma errors unrelated to these changes, so backend build could not complete.
- Attempted an automated Playwright screenshot (`mcp__browser_tools__run_playwright_script`) but the app was not running and navigation failed with `ERR_EMPTY_RESPONSE`.

Files changed: `backend/src/pinterest/pinterest.service.ts`, `frontend/src/services/pinterest-boards.ts`, `frontend/src/app/[user]/page.tsx`, `frontend/src/app/[user]/components/pins-list/index.tsx`, `frontend/src/store/slices/pins-slice/index.ts`, `frontend/src/app/[user]/components/control-bar/data.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfc8d92a8832d8e0e326b2d69037c)