### PR TITLE
Show up to 4 board pin previews and select board pins for drawing

### DIFF
--- a/backend/src/auth/services/pinterest-oauth.service.ts
+++ b/backend/src/auth/services/pinterest-oauth.service.ts
@@ -122,6 +122,29 @@ export class PinterestOAuthService {
       return (await response.json()) as PinterestPinsListResponse;
    }
 
+   async fetchBoardPins(accessToken: string, boardId: string, pageSize?: number, bookmark?: string) {
+      const boardPinsUrl = this.resolvePinterestApiUrl(`/boards/${boardId}/pins`);
+      if (pageSize !== undefined) {
+         boardPinsUrl.searchParams.set('page_size', String(pageSize));
+      }
+
+      if (bookmark) {
+         boardPinsUrl.searchParams.set('bookmark', bookmark);
+      }
+
+      const response = await fetch(boardPinsUrl.toString(), {
+         headers: {
+            Authorization: `Bearer ${accessToken}`,
+         },
+      });
+
+      if (!response.ok) {
+         throw new InternalServerErrorException('Failed to fetch Pinterest board pins');
+      }
+
+      return (await response.json()) as PinterestPinsListResponse;
+   }
+
    async fetchPinById(accessToken: string, pinId: string) {
       const pinUrl = this.resolvePinterestApiUrl(`/pins/${pinId}`);
       const response = await fetch(pinUrl.toString(), {

--- a/backend/src/pinterest/pinterest.controller.ts
+++ b/backend/src/pinterest/pinterest.controller.ts
@@ -33,6 +33,23 @@ export class PinterestController {
       return this.pinterestService.getBoardById(boardId, accessToken);
    }
 
+   @Get('boards/:boardId/pins')
+   async listBoardPins(
+      @PinterestAccessToken() accessToken: string,
+      @Param('boardId') boardId: string,
+      @Query('page_size') pageSizeRaw?: string,
+      @Query('bookmark') bookmark?: string,
+   ) {
+      const pageSize = pageSizeRaw ? Number.parseInt(pageSizeRaw, 10) : undefined;
+      const normalizedPageSize = pageSize && pageSize > 0 ? Math.min(250, pageSize) : undefined;
+
+      return this.pinterestService.listBoardPins(boardId, {
+         accessToken,
+         pageSize: normalizedPageSize,
+         bookmark,
+      });
+   }
+
    @Get('pins')
    async listPins(
       @PinterestAccessToken() accessToken: string,

--- a/frontend/src/app/[user]/components/control-bar/data.ts
+++ b/frontend/src/app/[user]/components/control-bar/data.ts
@@ -8,7 +8,7 @@ export const data = {
    secondaryButton: {
       title: 'Reset all',
    },
-   emptyText: 'Select images to start drawing',
+   emptyText: 'Select one board to start drawing',
    selectOption: [
       {
          name: 'duration',

--- a/frontend/src/app/[user]/components/pins-list/styles.module.scss
+++ b/frontend/src/app/[user]/components/pins-list/styles.module.scss
@@ -61,10 +61,19 @@
       }
    }
 
-   &__image-wrap {
+   &__preview-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-rows: repeat(2, 110px);
+      gap: 1px;
+      background: rgb(255 255 255 / 10%);
+      min-height: 220px;
+   }
+
+   &__preview-item {
       position: relative;
       width: 100%;
-      min-height: 220px;
+      height: 100%;
    }
 
    &__image {
@@ -103,13 +112,14 @@
    }
 
    &__placeholder {
-      min-height: 220px;
+      min-height: 100%;
       display: flex;
       justify-content: center;
       align-items: center;
       color: var(--white-color);
       font-family: Montserrat, sans-serif;
       opacity: 0.75;
+      font-size: 13px;
    }
 
    &__body {
@@ -125,25 +135,5 @@
       font-size: 18px;
       font-family: Montserrat, sans-serif;
       line-height: 1.3;
-   }
-
-   &__description {
-      margin: 0;
-      color: var(--white-color);
-      opacity: 0.9;
-      font-size: 14px;
-      line-height: 1.4;
-   }
-
-   &__link {
-      width: fit-content;
-      color: #8ed8ff;
-      font-size: 14px;
-      font-family: Montserrat, sans-serif;
-      text-decoration: none;
-
-      &:hover {
-         text-decoration: underline;
-      }
    }
 }

--- a/frontend/src/app/[user]/page.tsx
+++ b/frontend/src/app/[user]/page.tsx
@@ -3,7 +3,11 @@ import { notFound } from 'next/navigation'
 import { data as headerData } from '@/components/header/data'
 import IconButton from '@/components/ui/buttons/icon-button'
 import { getSessionUser } from '@/services/auth'
-import { getPinterestPins } from '@/services/pinterest-pins'
+import {
+   type AccountBoardWithPins,
+   getPinterestBoardPins,
+   getPinterestBoards,
+} from '@/services/pinterest-boards'
 import ControlBar from './components/control-bar'
 import PinsList from './components/pins-list'
 import UserInfo from './components/user-info'
@@ -22,8 +26,20 @@ export default async function UserPage({ params }: PageProps) {
    }
 
    const username = decodeURIComponent(session.user)
-   const pinsResponse = await getPinterestPins()
-   const { items: pins = [] } = pinsResponse ?? {}
+   const boardsResponse = await getPinterestBoards()
+   const { items: boards = [] } = boardsResponse ?? {}
+   const boardsWithPins: AccountBoardWithPins[] = await Promise.all(
+      boards.map(async (board) => {
+         const boardPinsResponse = await getPinterestBoardPins(board.id)
+         const pins = boardPinsResponse?.items ?? []
+
+         return {
+            ...board,
+            previewPins: pins.slice(0, 4),
+            pins,
+         }
+      }),
+   )
    const { logo } = headerData
 
    return (
@@ -37,7 +53,7 @@ export default async function UserPage({ params }: PageProps) {
             </div>
             <UserInfo username={username} profileImageUrl={session.profileImageUrl} />
          </div>
-         <PinsList pins={pins} />
+         <PinsList boards={boardsWithPins} />
          <ControlBar />
       </main>
    )

--- a/frontend/src/services/pinterest-boards.ts
+++ b/frontend/src/services/pinterest-boards.ts
@@ -1,0 +1,72 @@
+import { cookies } from 'next/headers'
+import type { AccountPin } from './pinterest-pins'
+
+export type AccountBoard = {
+   id: string
+   name: string | null
+   description: string | null
+   privacy: string | null
+   createdAt: string | null
+   imageUrl: string | null
+}
+
+export type AccountBoardWithPins = AccountBoard & {
+   previewPins: AccountPin[]
+   pins: AccountPin[]
+}
+
+type BoardsListResponse = {
+   items: AccountBoard[]
+   bookmark: string | null
+}
+
+type BoardPinsListResponse = {
+   items: AccountPin[]
+   bookmark: string | null
+}
+
+function getAuthHeaders(sessionCookieName: string, sessionToken?: string) {
+   return sessionToken ? { cookie: `${sessionCookieName}=${sessionToken}` } : undefined
+}
+
+export async function getPinterestBoards(pageSize = 24): Promise<BoardsListResponse | null> {
+   const backendUrl = process.env.BACKEND_API_URL
+   if (!backendUrl) {
+      throw new Error('BACKEND_API_URL is not set')
+   }
+
+   const sessionCookieName = process.env.SESSION_COOKIE_NAME ?? 'qd_session'
+   const cookieStore = await cookies()
+   const sessionToken = cookieStore.get(sessionCookieName)?.value
+   const response = await fetch(`${backendUrl}/pinterest/boards?page_size=${pageSize}`, {
+      headers: getAuthHeaders(sessionCookieName, sessionToken),
+      cache: 'no-store',
+   })
+
+   if (!response.ok) {
+      return null
+   }
+
+   return (await response.json()) as BoardsListResponse
+}
+
+export async function getPinterestBoardPins(boardId: string, pageSize = 250): Promise<BoardPinsListResponse | null> {
+   const backendUrl = process.env.BACKEND_API_URL
+   if (!backendUrl) {
+      throw new Error('BACKEND_API_URL is not set')
+   }
+
+   const sessionCookieName = process.env.SESSION_COOKIE_NAME ?? 'qd_session'
+   const cookieStore = await cookies()
+   const sessionToken = cookieStore.get(sessionCookieName)?.value
+   const response = await fetch(`${backendUrl}/pinterest/boards/${boardId}/pins?page_size=${pageSize}`, {
+      headers: getAuthHeaders(sessionCookieName, sessionToken),
+      cache: 'no-store',
+   })
+
+   if (!response.ok) {
+      return null
+   }
+
+   return (await response.json()) as BoardPinsListResponse
+}

--- a/frontend/src/store/slices/pins-slice/index.ts
+++ b/frontend/src/store/slices/pins-slice/index.ts
@@ -4,11 +4,18 @@ import { AccountPin } from '@/services/pinterest-pins'
 export interface PinState {
    pins: AccountPin[]
    selectedPins: AccountPin[]
+   selectedBoardId: string | null
+}
+
+type SelectBoardPayload = {
+   boardId: string
+   pins: AccountPin[]
 }
 
 const initialState: PinState = {
    pins: [],
    selectedPins: [],
+   selectedBoardId: null,
 }
 
 const pinsSlice = createSlice({
@@ -18,28 +25,33 @@ const pinsSlice = createSlice({
       setPins: (state, action: PayloadAction<AccountPin[]>) => {
          state.pins = action.payload
          const availablePinIds = new Set(action.payload.map((pin) => pin.id))
-         state.selectedPins = state.selectedPins.filter((pin) => availablePinIds.has(pin.id))
+         if (state.selectedBoardId && !availablePinIds.has(state.selectedBoardId)) {
+            state.selectedPins = []
+            state.selectedBoardId = null
+         }
       },
-      togglePinSelection: (state, action: PayloadAction<AccountPin>) => {
-         const pin = action.payload
-         const pinExists = state.pins.some((statePin) => statePin.id === pin.id)
-         if (!pinExists) {
+      toggleBoardSelection: (state, action: PayloadAction<SelectBoardPayload>) => {
+         const { boardId, pins } = action.payload
+         const boardExists = state.pins.some((statePin) => statePin.id === boardId)
+         if (!boardExists) {
             return
          }
 
-         const pinIndex = state.selectedPins.findIndex((selectedPin) => selectedPin.id === pin.id)
-         if (pinIndex >= 0) {
-            state.selectedPins.splice(pinIndex, 1)
+         if (state.selectedBoardId === boardId) {
+            state.selectedPins = []
+            state.selectedBoardId = null
             return
          }
 
-         state.selectedPins.push(pin)
+         state.selectedPins = pins
+         state.selectedBoardId = boardId
       },
       resetPinSelection: (state) => {
          state.selectedPins = []
+         state.selectedBoardId = null
       },
    },
 })
 
-export const { setPins, togglePinSelection, resetPinSelection } = pinsSlice.actions
+export const { setPins, toggleBoardSelection, resetPinSelection } = pinsSlice.actions
 export default pinsSlice.reducer


### PR DESCRIPTION
### Motivation
- Show actual pins from each Pinterest board as a 2x2 preview (not the board cover) and limit that preview to at most four images for a compact card view.
- Ensure the drawing flow receives the real set of images from the selected board (all pins), and enforce single-board selection so drawing always gets a single, well-defined set of pins.

### Description
- Backend: added `GET /pinterest/boards/:boardId/pins` and implemented `fetchBoardPins` in `PinterestOAuthService` plus `listBoardPins` in `PinterestService` so board pins are fetched and normalized (`backend/src/auth/services/pinterest-oauth.service.ts`, `backend/src/pinterest/pinterest.service.ts`, `backend/src/pinterest/pinterest.controller.ts`).
- Frontend service: added `frontend/src/services/pinterest-boards.ts` with `getPinterestBoards` and `getPinterestBoardPins`, and new type `AccountBoardWithPins` containing `previewPins` (up to 4) and `pins` (all board pins).
- Page & UI: updated `/<user>` data loading to fetch each board's pins and attach `previewPins = pins.slice(0, 4)` and `pins` to the board objects, and reworked `PinsList` to display a 2x2 preview grid using `previewPins` (max 4) (`frontend/src/app/[user]/page.tsx`, `frontend/src/app/[user]/components/pins-list/index.tsx`, `frontend/src/app/[user]/components/pins-list/styles.module.scss`).
- Selection state: changed the pins slice to track a single selected board via `selectedBoardId` and to store the board's full `pins` in `selectedPins` when selecting a board, with toggling clearing selection (`frontend/src/store/slices/pins-slice/index.ts`).
- Small UX copy update: changed control bar empty-state text to `Select one board to start drawing` (`frontend/src/app/[user]/components/control-bar/data.ts`).

### Testing
- Ran `BACKEND_API_URL=https://example.com yarn --cwd frontend build`, which completed successfully in this environment.
- Started the frontend dev server with `yarn --cwd frontend dev -p 3000` and produced a browser screenshot of `/test-user` to validate the board-list rendering; the screenshot run completed.
- Observed that running dev without `BACKEND_API_URL` causes server-side compilation errors from `getSessionUser` (error: `BACKEND_API_URL is not set`), so local dev must set `BACKEND_API_URL` for server-rendered routes; no backend build/test was executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfc8d92a8832d8e0e326b2d69037c)