### PR TITLE
Make preview thumbnails scrollable with arrows and auto-scroll active item

### DIFF
--- a/frontend/src/components/image-slider/components/preview-section/components/preview-images/index.tsx
+++ b/frontend/src/components/image-slider/components/preview-section/components/preview-images/index.tsx
@@ -1,11 +1,15 @@
 'use client'
 
 import cn from 'classnames'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { AccountPin } from '@/services/pinterest-pins'
 import { useAppDispatch } from '@/store/hooks'
 import { goToImage } from '@/store/slices/image-slider-slice'
 import { PreviewImagesProps } from '../../../../types'
 import styles from './styles.module.scss'
+
+const MAX_VISIBLE_PREVIEW_COUNT = 8
+const PREVIEW_SCROLL_STEP = 240
 
 export const PreviewImages = ({
    data,
@@ -14,6 +18,45 @@ export const PreviewImages = ({
    isFinished,
 }: PreviewImagesProps) => {
    const dispatch = useAppDispatch()
+   const viewportRef = useRef<HTMLDivElement>(null)
+   const [canScrollLeft, setCanScrollLeft] = useState(false)
+   const [canScrollRight, setCanScrollRight] = useState(false)
+
+   const isSliderEnabled = data.length > MAX_VISIBLE_PREVIEW_COUNT
+
+   const updateArrowState = useCallback(() => {
+      if (!viewportRef.current || !isSliderEnabled) {
+         setCanScrollLeft(false)
+         setCanScrollRight(false)
+         return
+      }
+
+      const { scrollLeft, scrollWidth, clientWidth } = viewportRef.current
+      const maxScrollLeft = scrollWidth - clientWidth
+
+      setCanScrollLeft(scrollLeft > 2)
+      setCanScrollRight(scrollLeft < maxScrollLeft - 2)
+   }, [isSliderEnabled])
+
+   useEffect(() => {
+      updateArrowState()
+   }, [data.length, updateArrowState])
+
+   useEffect(() => {
+      if (!isSliderEnabled) {
+         return
+      }
+
+      const activePreview = viewportRef.current?.children[currentIndex] as
+         | HTMLButtonElement
+         | undefined
+
+      activePreview?.scrollIntoView({
+         behavior: 'smooth',
+         inline: 'nearest',
+         block: 'nearest',
+      })
+   }, [currentIndex, isSliderEnabled])
 
    const getPreviewClassName = (isActive: boolean, imageIndex: number) =>
       cn(styles['preview-images__image'], {
@@ -34,27 +77,75 @@ export const PreviewImages = ({
 
    const canInteract = (imageIndex: number) => imageIndex <= progressIndex || isFinished
 
-   return (
-      <>
-         {data?.map((image, imageIndex) => {
-            const isActive = imageIndex === currentIndex
-            const isInteractive = canInteract(imageIndex)
+   const handleScroll = (direction: 'left' | 'right') => {
+      if (!viewportRef.current) {
+         return
+      }
 
-            return (
-               <button
-                  type="button"
-                  key={image.id}
-                  disabled={isActive}
-                  aria-label="preview-image"
-                  className={getPreviewClassName(isActive, imageIndex)}
-                  onClick={() => isInteractive && dispatch(goToImage(imageIndex))}
-                  style={{
-                     backgroundImage: getBackgroundImage(image, isActive, imageIndex),
-                     cursor: isInteractive && !isActive ? 'pointer' : '',
-                  }}
-               />
-            )
-         })}
-      </>
+      const nextScrollLeft =
+         direction === 'left'
+            ? viewportRef.current.scrollLeft - PREVIEW_SCROLL_STEP
+            : viewportRef.current.scrollLeft + PREVIEW_SCROLL_STEP
+
+      viewportRef.current.scrollTo({ left: nextScrollLeft, behavior: 'smooth' })
+   }
+
+   const renderImages = () =>
+      data?.map((image, imageIndex) => {
+         const isActive = imageIndex === currentIndex
+         const isInteractive = canInteract(imageIndex)
+
+         return (
+            <button
+               type="button"
+               key={image.id}
+               disabled={isActive}
+               aria-label="preview-image"
+               className={getPreviewClassName(isActive, imageIndex)}
+               onClick={() => isInteractive && dispatch(goToImage(imageIndex))}
+               style={{
+                  backgroundImage: getBackgroundImage(image, isActive, imageIndex),
+                  cursor: isInteractive && !isActive ? 'pointer' : '',
+               }}
+            />
+         )
+      })
+
+   return (
+      <div className={styles['preview-images']}>
+         {isSliderEnabled && (
+            <button
+               type="button"
+               aria-label="scroll-previews-left"
+               className={styles['preview-images__arrow']}
+               onClick={() => handleScroll('left')}
+               disabled={!canScrollLeft}
+            >
+               ‹
+            </button>
+         )}
+
+         <div
+            ref={viewportRef}
+            onScroll={updateArrowState}
+            className={cn(styles['preview-images__viewport'], {
+               [styles['preview-images__viewport--slider']]: isSliderEnabled,
+            })}
+         >
+            {renderImages()}
+         </div>
+
+         {isSliderEnabled && (
+            <button
+               type="button"
+               aria-label="scroll-previews-right"
+               className={styles['preview-images__arrow']}
+               onClick={() => handleScroll('right')}
+               disabled={!canScrollRight}
+            >
+               ›
+            </button>
+         )}
+      </div>
    )
 }

--- a/frontend/src/components/image-slider/components/preview-section/components/preview-images/styles.module.scss
+++ b/frontend/src/components/image-slider/components/preview-section/components/preview-images/styles.module.scss
@@ -1,7 +1,45 @@
 .preview-images {
+   display: flex;
+   align-items: center;
+   gap: 8px;
+
+   &__viewport {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+   }
+
+   &__viewport--slider {
+      max-width: 470px;
+      overflow-x: auto;
+      scroll-behavior: smooth;
+      scrollbar-width: none;
+
+      &::-webkit-scrollbar {
+         display: none;
+      }
+   }
+
+   &__arrow {
+      width: 28px;
+      height: 28px;
+      border: none;
+      border-radius: 50%;
+      background-color: rgb(0 0 0 / 50%);
+      color: var(--light-gray-color);
+      cursor: pointer;
+      transition: opacity 0.2s;
+
+      &:disabled {
+         opacity: 0.35;
+         cursor: not-allowed;
+      }
+   }
+
    &__image {
       position: relative;
       width: 50px;
+      min-width: 50px;
       height: 50px;
       border-radius: 8px;
       background-size: cover;


### PR DESCRIPTION
### Motivation
- Enable horizontal scrolling for preview thumbnails when there are many images to improve usability and avoid overflow. 
- Provide arrow controls and automatic centering of the active preview so users can easily navigate large image lists.
- Keep disabled/unrevealed previews visually distinct and non-interactive until available.

### Description
- Introduced constants `MAX_VISIBLE_PREVIEW_COUNT` and `PREVIEW_SCROLL_STEP` and added `viewportRef`, `canScrollLeft`, and `canScrollRight` state to manage a scrollable preview viewport. 
- Implemented `updateArrowState`, `handleScroll`, and an effect to `scrollIntoView` the active preview, and replaced inline mapping with a `renderImages` helper to render preview buttons. 
- Conditionally render left/right arrow buttons when `data.length > MAX_VISIBLE_PREVIEW_COUNT` and wire them to scroll the viewport; arrows are disabled when scrolling is not possible. 
- Added new stylesheet rules to layout the preview container (`.preview-images`), create a hidden-scroll slider viewport (`&__viewport--slider`), style arrow buttons (`&__arrow`), and ensure preview items maintain size and spacing.

### Testing
- Ran the frontend unit test suite with `yarn test` and the linter with `yarn lint`, and both completed successfully. 
- Verified component behavior in the browser manually to ensure arrows, smooth scrolling, and `scrollIntoView` for the active item work as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee5795edc832d826170599c926bc2)